### PR TITLE
APIキーの環境変数名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - 以下のコマンドを実行してください
 
 ```bash
-export OPEN_AI_API_KEY=*****
+export OPENAI_API_KEY=*****
 git clone ...
 cd charites-ai
 npm ci


### PR DESCRIPTION
@yuiseki 
興味深いプロジェクトありがとうございます! 

OPEN AI の APIキーを `OPEN_AI_API_KEY` という環境変数で出力したところ、以下のエラーが出たので、[LangChain のクイックスタート](https://js.langchain.com/docs/get_started/quickstart#environment-setup) に沿って、`OPENAI_API_KEY` に変更しました。


```
Error: OpenAI or Azure OpenAI API key not found
    at new OpenAIEmbeddings (file:///Users/naoppy/geolonia/charites-ai/node_modules/langchain/dist/embeddings/openai.js:103:19)
    at file:///Users/naoppy/geolonia/charites-ai/scripts/embed.ts:70:20
```